### PR TITLE
Fix asUnHtml - Do not add semicolons, if they are not present

### DIFF
--- a/packages/HTML.package/DHtmlFormatterTest.class/instance/test06NonHtmlEntitiesShouldBeReturned.st
+++ b/packages/HTML.package/DHtmlFormatterTest.class/instance/test06NonHtmlEntitiesShouldBeReturned.st
@@ -2,7 +2,7 @@ testing
 test06NonHtmlEntitiesShouldBeReturned
 	| document |
 	document := HtmlDocument new.
-	document parseContents: (ReadStream on:'&squeak;<!-- begin <Tag> end -->').
+	document parseContents: (ReadStream on:'&squeak;<!-- begin <Tag> end --> & text').
 	document addToFormatter: (self htmlFormatter).
-	self assert: '&squeak;' equals: self htmlFormatter text asString.
+	self assert: '&squeak; & text' equals: self htmlFormatter text asString.
 	self assert: '<!-- begin <Tag> end -->' equals: document children second rawContent.

--- a/packages/HTML.package/DHtmlFormatterTest.class/methodProperties.json
+++ b/packages/HTML.package/DHtmlFormatterTest.class/methodProperties.json
@@ -8,7 +8,7 @@
 		"test03HtmlEntitiesShouldBeParsedCorrectly" : "SS 5/27/2014 22:08",
 		"test04DecimalHtmlEntitiesShouldBeParsedCorrectly" : "SS 5/27/2014 21:24",
 		"test05HexadecimalHtmlEntitiesShouldBeParsedCorrectly" : "SS 5/27/2014 22:09",
-		"test06NonHtmlEntitiesShouldBeReturned" : "SS 6/21/2014 12:17",
+		"test06NonHtmlEntitiesShouldBeReturned" : "SS 6/21/2014 14:11",
 		"test07HtmlEntitiesShouldBeParsedEverywhere" : "SS 6/5/2014 19:04",
 		"test08OrderedListsShouldHaveNumbers" : "pf 6/12/2014 12:16",
 		"test09OrderedListsShouldHaveCustomizableStartValues" : "pf 6/12/2014 12:16",

--- a/packages/HTML.package/String.extension/instance/asUnHtml.st
+++ b/packages/HTML.package/String.extension/instance/asUnHtml.st
@@ -19,7 +19,11 @@ they were in text."
 												rest second asLowercase = $x ifTrue: 
 													[rest := '#16r', rest allButFirst allButFirst].
 												Character value: rest allButFirst asNumber]
-											ifFalse: ['&', rest, ';']]) asString]
+											ifFalse: [
+												in last = $;
+													ifTrue: ['&', rest, ';']
+													ifFalse: ['&', rest]
+													]]) asString]
 						ifFalse: [out nextPut: char]].
 		].
 	^ out contents

--- a/packages/HTML.package/String.extension/methodProperties.json
+++ b/packages/HTML.package/String.extension/methodProperties.json
@@ -2,7 +2,7 @@
 	"class" : {
 		 },
 	"instance" : {
-		"asUnHtml" : "SS 5/27/2014 22:13",
+		"asUnHtml" : "SS 6/21/2014 14:11",
 		"content" : "tb 1/17/2008 14:57",
 		"splitOn:" : "tb 1/17/2008 14:21",
 		"trimBoth" : "lr 10/25/2009 11:13",

--- a/packages/HTML.package/monticello.meta/version
+++ b/packages/HTML.package/monticello.meta/version
@@ -1,1 +1,1 @@
-b8ea53a7-eb05-674a-9c3e-1bd7146442aa
+f0fc1c9b-07b9-4cb3-afcf-b6988230c193

--- a/packages/HTML.package/monticello.meta/version.d/HTML-SS.91_e82b1158-e908-4e66-8086-67e75739d556
+++ b/packages/HTML.package/monticello.meta/version.d/HTML-SS.91_e82b1158-e908-4e66-8086-67e75739d556
@@ -1,1 +1,0 @@
-(name 'HTML-SS.91'message 'Do not display HTML comments.'id 'e82b1158-e908-4e66-8086-67e75739d556'date '21 June 2014'time '12:27:49.493 pm'author 'SS'ancestors ((id 'c8f00ec2-0036-9e4e-9ca2-19ecd4655555'))stepChildren ())

--- a/packages/HTML.package/monticello.meta/version.d/HTML-SS.94_f0fc1c9b-07b9-4cb3-afcf-b6988230c193
+++ b/packages/HTML.package/monticello.meta/version.d/HTML-SS.94_f0fc1c9b-07b9-4cb3-afcf-b6988230c193
@@ -1,0 +1,1 @@
+(name 'HTML-SS.94'message 'Do not display semicolons for text with ampersands at the end after asUnHtml processed the string'id 'f0fc1c9b-07b9-4cb3-afcf-b6988230c193'date '21 June 2014'time '2:15:26.361 pm'author 'SS'ancestors ((id 'b8ea53a7-eb05-674a-9c3e-1bd7146442aa'))stepChildren ())


### PR DESCRIPTION
Do not display semicolons for text with ampersands at the end after asUnHtml processed the string.
