### PR TITLE
Add subclass of PluggableTextMorph that can submit on pressing enter

### DIFF
--- a/packages/HTML.package/HtmlINPUTNode.class/instance/addTextInputToFormatter..st
+++ b/packages/HTML.package/HtmlINPUTNode.class/instance/addTextInputToFormatter..st
@@ -2,7 +2,7 @@ rendering
 addTextInputToFormatter: formatter
 	"is it a submit button?"
 	| inputMorph size |
-	inputMorph := PluggableTextMorph on: StringHolder new text: #contents accept: #acceptContents:.
+	inputMorph := PluggableTextMorphSubmitOnEnter on: StringHolder new text: #contents accept: #acceptContents: acceptTarget: self associatedForm acceptAction: #submitAsync.
 	self type = 'password'
 		ifTrue: [inputMorph font: (StrikeFont passwordFontSize: 12)].
 	size := (self attributes at: 'size' ifAbsent: ['12']) asNumber.

--- a/packages/HTML.package/HtmlINPUTNode.class/methodProperties.json
+++ b/packages/HTML.package/HtmlINPUTNode.class/methodProperties.json
@@ -6,7 +6,7 @@
 		"addFileInputToFormatter:" : "rs 5/29/2014 23:19:04.282",
 		"addImageButtonToFormatter:" : "rs 5/29/2014 23:18:49.476",
 		"addRadioButtonToFormatter:" : "rs 5/29/2014 23:18:42.71",
-		"addTextInputToFormatter:" : "rs 6/7/2014 15:48:42.03",
+		"addTextInputToFormatter:" : "KD 5/25/2018 11:52",
 		"addToFormatter:" : "rs 5/30/2014 16:38:10.784",
 		"alt" : "SN 5/22/2014 11:49",
 		"defaultValue" : "SS 5/27/2014 20:35",

--- a/packages/Scamper.package/PluggableTextMorphSubmitOnEnter.class/class/on.text.accept.acceptTarget.acceptAction..st
+++ b/packages/Scamper.package/PluggableTextMorphSubmitOnEnter.class/class/on.text.accept.acceptTarget.acceptAction..st
@@ -1,0 +1,10 @@
+as yet unclassified
+on: stringModel text: getTextSel accept: setTextSel acceptTarget: acceptObject acceptAction: aSymbol
+
+	| plugTextMorph |
+	plugTextMorph := self on: stringModel text: getTextSel accept: setTextSel.
+	plugTextMorph acceptTarget: acceptObject.
+	plugTextMorph acceptAction: aSymbol.
+	^plugTextMorph
+	
+	

--- a/packages/Scamper.package/PluggableTextMorphSubmitOnEnter.class/instance/accept.st
+++ b/packages/Scamper.package/PluggableTextMorphSubmitOnEnter.class/instance/accept.st
@@ -1,0 +1,5 @@
+as yet unclassified
+accept
+	super accept.
+	self acceptTarget perform: acceptAction. 
+		

--- a/packages/Scamper.package/PluggableTextMorphSubmitOnEnter.class/instance/acceptAction..st
+++ b/packages/Scamper.package/PluggableTextMorphSubmitOnEnter.class/instance/acceptAction..st
@@ -1,0 +1,3 @@
+accessing
+acceptAction: anObject
+	acceptAction := anObject

--- a/packages/Scamper.package/PluggableTextMorphSubmitOnEnter.class/instance/acceptAction.st
+++ b/packages/Scamper.package/PluggableTextMorphSubmitOnEnter.class/instance/acceptAction.st
@@ -1,0 +1,3 @@
+accessing
+acceptAction
+	^ acceptAction

--- a/packages/Scamper.package/PluggableTextMorphSubmitOnEnter.class/instance/acceptTarget..st
+++ b/packages/Scamper.package/PluggableTextMorphSubmitOnEnter.class/instance/acceptTarget..st
@@ -1,0 +1,3 @@
+accessing
+acceptTarget: anObject
+	acceptTarget := anObject

--- a/packages/Scamper.package/PluggableTextMorphSubmitOnEnter.class/instance/acceptTarget.st
+++ b/packages/Scamper.package/PluggableTextMorphSubmitOnEnter.class/instance/acceptTarget.st
@@ -1,0 +1,3 @@
+accessing
+acceptTarget
+	^ acceptTarget

--- a/packages/Scamper.package/PluggableTextMorphSubmitOnEnter.class/instance/initialize.st
+++ b/packages/Scamper.package/PluggableTextMorphSubmitOnEnter.class/instance/initialize.st
@@ -1,0 +1,4 @@
+as yet unclassified
+initialize 
+	super initialize.
+	self acceptOnCR: true.

--- a/packages/Scamper.package/PluggableTextMorphSubmitOnEnter.class/methodProperties.json
+++ b/packages/Scamper.package/PluggableTextMorphSubmitOnEnter.class/methodProperties.json
@@ -1,0 +1,10 @@
+{
+	"class" : {
+		"on:text:accept:acceptTarget:acceptAction:" : "KD 5/25/2018 11:47" },
+	"instance" : {
+		"accept" : "KD 5/25/2018 11:51",
+		"acceptAction" : "KD 5/25/2018 11:40",
+		"acceptAction:" : "KD 5/25/2018 11:40",
+		"acceptTarget" : "KD 5/25/2018 11:40",
+		"acceptTarget:" : "KD 5/25/2018 11:40",
+		"initialize" : "KD 5/25/2018 11:33" } }

--- a/packages/Scamper.package/PluggableTextMorphSubmitOnEnter.class/properties.json
+++ b/packages/Scamper.package/PluggableTextMorphSubmitOnEnter.class/properties.json
@@ -1,0 +1,17 @@
+{
+	"category" : "Scamper-HTML-Morphs",
+	"classinstvars" : [
+		 ],
+	"classvars" : [
+		 ],
+	"commentStamp" : "",
+	"instvars" : [
+		"nodes",
+		"incompleteMorphs",
+		"acceptTarget",
+		"acceptAction" ],
+	"name" : "PluggableTextMorphSubmitOnEnter",
+	"pools" : [
+		 ],
+	"super" : "PluggableTextMorph",
+	"type" : "normal" }

--- a/packages/Scamper.package/Scamper.class/methodProperties.json
+++ b/packages/Scamper.package/Scamper.class/methodProperties.json
@@ -4,7 +4,6 @@
 		"StartUrl:" : "LaurentLaffont 2/26/2010 23:08",
 		"addLongtimeCookie:" : "wg 6/23/2015 01:21",
 		"fileReaderServicesForFile:suffix:" : "sd 2/6/2002 21:36",
-    "initialize" : "KD 5/22/2018 13:09",
 		"initialize" : "LL 5/23/2018 12:58",
 		"install" : "LL 5/23/2018 13:01",
 		"longtimeCookies" : "wp 7/19/2015 02:32:50.053",


### PR DESCRIPTION
Created Subclass of PluggableTextMorph in Scamper-Html_Morphs package that gets additional acceptTarget and acceptAction as arguments on instance creation. This way, the underlying stringModel of the TextMorph remains untouched an we just send the acceptAction to the acceptTarget when accept is called.