### PR TITLE
Set Scamper as default WebBrowser during initialization

### DIFF
--- a/packages/Scamper.package/Scamper.class/class/initialize.st
+++ b/packages/Scamper.package/Scamper.class/class/initialize.st
@@ -3,4 +3,6 @@ initialize
 	"Initialize the class"
 	self StartUrl: self StartUrl.
 	FileList registerFileReader: self.
-	WebBrowser register: self.
+	WebBrowser
+		register: self;
+		default: self.


### PR DESCRIPTION
I would not be aware of any other relevant WebBrowser implementation in Squeak, so why don't set Scamper als default?

The default setting is used in TextURL, for example.